### PR TITLE
在后台打开打开标签时，新的标签在当前标签页后面打开

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -2725,7 +2725,13 @@ var sub={
 			}
 		if(!theURL){delete createProperties.url}
 		if(!(thePos||thePos===0)){delete createProperties.index}
-		chrome.tabs.create(createProperties);
+		chrome.tabs.query({
+			active: true,
+			currentWindow: true
+		}, function(tabs) {
+			createProperties["openerTabId"] = tabs[0].id
+			chrome.tabs.create(createProperties);
+		});
 
 		//(thePos||thePos===0)?chrome.tabs.create({url:theURL,active:theTarget=="s_back"?false:true,index:thePos,pinned:thePin}):chrome.tabs.create({url:theURL,active:theTarget=="s_back"?false:true,pinned:thePin})
 	},


### PR DESCRIPTION
目前由于在create tab的时候，没有加openerTabId参数，所有的后台tab默认都开在最后了。
这次加上了openerTabId这个参数，来实现类似浏览器右键的“在新的标签页中打开”的效果。
但是由于函数是使用callback来获取tab id的，我也不太清楚有没有更优雅的写法-w-。